### PR TITLE
Improve Editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,12 @@
+root = true
+
 [*]
 charset = utf-8
 end_of_line = lf
 indent_size = 2
 insert_final_newline = true
+trim_trailing_whitespace = true
 indent_style = space
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
I detected an issue these days: trailing whitespaces weren't automatically removed. That was kind of annoying, so here's the fix.

I applied that improvement to all files but markdown, because the sequence (2spaces + newline) is translated into `<br/>`.