### PR TITLE
Add a new "Improvement" tag for the "Better comments" extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,6 +5,7 @@
     "ms-vscode.vscode-typescript-tslint-plugin",
     "editorconfig.editorconfig",
     "davidanson.vscode-markdownlint",
-    "hbenl.vscode-mocha-test-adapter"
+    "hbenl.vscode-mocha-test-adapter",
+    "aaron-bond.better-comments"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,43 @@
     ],
     "editor.codeActionsOnSave": {
       "source.fixAll.tslint": true
-    }
+    },
+    "better-comments.tags": [
+      {
+        "tag": "!",
+        "color": "#FF2D00",
+        "strikethrough": false,
+        "backgroundColor": "transparent"
+      },
+      {
+        "tag": "?",
+        "color": "#3498DB",
+        "strikethrough": false,
+        "backgroundColor": "transparent"
+      },
+      {
+        "tag": "//",
+        "color": "#474747",
+        "strikethrough": true,
+        "backgroundColor": "transparent"
+      },
+      {
+        "tag": "todo",
+        "color": "#FF8C00",
+        "strikethrough": false,
+        "backgroundColor": "transparent"
+      },
+      {
+        "tag": "*",
+        "color": "#98C379",
+        "strikethrough": false,
+        "backgroundColor": "transparent"
+      },
+      {
+        "tag": "improvement",
+        "color": "#DD3D84",
+        "strikethrough": false,
+        "backgroundColor": "transparent"
+      }
+    ]
 }


### PR DESCRIPTION
I really like the "Better comments" extension to highlight some relevant comments. @sergioluis suggested that we could really use a new "Improvement" tag for all those situations where you realize you could really improve something but you're on a tight schedule.

This tag would be helpful to prevent those ideas from fading away.